### PR TITLE
Bump flurry dep to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ android {
   buildToolsVersion '25.0.2'
 
   defaultConfig {
-    minSdkVersion 14
+    minSdkVersion 16
     targetSdkVersion 25
   }
 
@@ -40,7 +40,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.flurry.android:analytics:7.0.1@aar'
+  compile 'com.flurry.android:analytics:8.0.2@aar'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.3.1') {


### PR DESCRIPTION
- Bumps Flurry dependency to latest
- Flurry will not support jar files in the near future and suggests tagging the dep as `@aar`
- Bumps minSdkVersion to minimum supported by Flurry 8.0.2