### PR TITLE
[DEST-1542] Bump flurry sdk to 12.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 4.0.0 (14th April, 2020)
+==================================
+*(Supports Flurry 12.3.0)*
+
+  * Bump Flurry to version 12.3.0
+  * Removes support for onPage and setLocation calls
+
 Version 3.0.0 (7th November, 2017)
 ==================================
 *(Supports Flurry 8.0.2+)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@ Version 4.0.0 (14th April, 2020)
 ==================================
 *(Supports Flurry 12.3.0)*
 
+  * Breaking: support for onPage and setLocation calls
   * Bump Flurry to version 12.3.0
-  * Removes support for onPage and setLocation calls
+
+   Note: Please see [Flurry release notes](https://developer.yahoo.com/flurry/docs/releasenotes/android/#android-sdk-release-notes) for complete list of changes.
+
 
 Version 3.0.0 (7th November, 2017)
 ==================================

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,14 @@
 Releasing
 ========
 
- 1. Change the version in `gradle.properties` to a non-SNAPSHOT version.
- 2. Update the `CHANGELOG.md` for the impending release.
- 3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
- 4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
- 5. `./gradlew clean uploadArchives`
- 6. Update the `gradle.properties` to the next SNAPSHOT version.
- 7. `git commit -am "Prepare next development version."`
- 8. `git push && git push --tags`
- 9. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+ 1. Make changes, get approval, merge to master, checkout master locally.
+ 2. Change the version in `gradle.properties` to a non-SNAPSHOT version.
+ 3. Change VERSION_CODE to match semver, ie (`v3.0.1` -> `VERSION_CODE=301`).
+ 4. Update the `CHANGELOG.md` for the impending release.
+ 5. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
+ 6. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
+ 7. `./gradlew clean uploadArchives`
+ 8. Update the `gradle.properties` to the next SNAPSHOT version.
+ 9. `git commit -am "Prepare next development version."`
+ 10. `git push && git push --tags`
+ 11. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.flurry.android:analytics:8.0.2@aar'
+  compile group: 'com.flurry.android', name: 'analytics', version: '11.6.0'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.3.1') {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile group: 'com.flurry.android', name: 'analytics', version: '11.6.0'
+  compile group: 'com.flurry.android', name: 'analytics', version: '12.3.0'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.3.1') {

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.f2prateek.javafmt'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion '25.0.2'
+  compileSdkVersion 26
+  buildToolsVersion '26.0.2'
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 25
+    targetSdkVersion 26
   }
 
   compileOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.segment.analytics.android.integrations
 
 VERSION_CODE=301
-VERSION_NAME=3.0.1-SNAPSHOT
+VERSION_NAME=4.0.0
 
 POM_ARTIFACT_ID=flurry
 POM_PACKAGING=aar

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION_CODE=301
+VERSION_CODE=400
 VERSION_NAME=4.0.0
 
 POM_ARTIFACT_ID=flurry

--- a/src/main/java/com/segment/analytics/android/integrations/flurry/FlurryIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/flurry/FlurryIntegration.java
@@ -122,8 +122,6 @@ public class FlurryIntegration extends Integration<Void> {
   @Override
   public void screen(ScreenPayload screen) {
     super.screen(screen);
-    // todo: verify behaviour here, iOS SDK only does pageView, not event
-    logger.verbose("FlurryAgent.onPageView();");
 
     String event = screen.event();
     Map<String, String> properties = screen.properties().toStringMap();
@@ -169,7 +167,5 @@ public class FlurryIntegration extends Integration<Void> {
       FlurryAgent.setGender(genderConstant);
       logger.verbose("FlurryAgent.setGender(%s);", genderConstant);
     }
-
-    AnalyticsContext.Location location = identify.context().location();
   }
 }

--- a/src/main/java/com/segment/analytics/android/integrations/flurry/FlurryIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/flurry/FlurryIntegration.java
@@ -123,7 +123,6 @@ public class FlurryIntegration extends Integration<Void> {
   public void screen(ScreenPayload screen) {
     super.screen(screen);
     // todo: verify behaviour here, iOS SDK only does pageView, not event
-    FlurryAgent.onPageView();
     logger.verbose("FlurryAgent.onPageView();");
 
     String event = screen.event();
@@ -172,11 +171,5 @@ public class FlurryIntegration extends Integration<Void> {
     }
 
     AnalyticsContext.Location location = identify.context().location();
-    if (location != null) {
-      float latitude = (float) location.latitude();
-      float longitude = (float) location.longitude();
-      FlurryAgent.setLocation(latitude, longitude);
-      logger.verbose("FlurryAgent.setLocation(%s, %s);", latitude, longitude);
-    }
   }
 }

--- a/src/test/java/com/segment/analytics/android/integrations/flurry/FlurryTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/flurry/FlurryTest.java
@@ -118,8 +118,6 @@ public class FlurryTest {
   @Test public void screen() {
     integration.screen(new ScreenPayloadBuilder().name("foo").category("bar").build());
     verifyStatic();
-    FlurryAgent.onPageView();
-    verifyStatic();
     FlurryAgent.logEvent(eq("foo"), Matchers.<Map<String, String>>any());
   }
 
@@ -149,6 +147,5 @@ public class FlurryTest {
     verifyStatic();
     FlurryAgent.setGender(Constants.FEMALE);
     verifyStatic();
-    FlurryAgent.setLocation(20, 20);
   }
 }

--- a/src/test/java/com/segment/analytics/android/integrations/flurry/FlurryTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/flurry/FlurryTest.java
@@ -146,6 +146,5 @@ public class FlurryTest {
     FlurryAgent.setAge(3);
     verifyStatic();
     FlurryAgent.setGender(Constants.FEMALE);
-    verifyStatic();
   }
 }


### PR DESCRIPTION
https://segment.atlassian.net/browse/DEST-1542

Bumps Flurry sdk version to v12.3.0. 

**Breaking Change**
`onPageView()` and `setLocation()` are deprecated as of [v12.0.0](https://developer.yahoo.com/flurry/docs/releasenotes/android/#version-12-2-0-1-9-2020). It looks like exact location data has been completely removed from future releases. `onPageView()` looks like it forwarded a count of times the page had been viewed, which doesn't seem critical enough to hold up this release for (other event data from the page is still tracked). It was not immediately obvious what changes, if any, could be made that would restore partial functionality of these methods. 

I've opted to totally remove these deprecated methods for version 4.0.0 of our integration. If we need to make major upgrades to this integration recreate either `onPageView()` or `setLocation()`, we should do so in another ticket. 

I also had to bump Android SDK to v26 (required by Google Play), and build tools to 26.0.2.
